### PR TITLE
Remove integration test for prod site

### DIFF
--- a/tests/integration-tests_spec.js
+++ b/tests/integration-tests_spec.js
@@ -16,13 +16,14 @@ frisby.create('Testing Adverse Reaction Events GET')
     .expectStatus(200)
 .toss();
 
+/*
 console.log('Testing BE Safe Website Availability')
 frisby.create('Testing BE Safe Website Availability')
     .get('https://be-safe.buchanan-edwards.com/#/')
     //.expectHeader('Content-Type', 'application/json; charset=utf-8')
     .expectStatus(200)
 .toss();
-
+*/
 console.log('Testing AWS Availability')
 frisby.create('Testing AWS Availability')
     .get('http://status.aws.amazon.com/')


### PR DESCRIPTION
Remove the integration test for the production url while the ssl issue is being addressed.